### PR TITLE
archivista: update charts to v0.9.0

### DIFF
--- a/charts/archivista/Chart.yaml
+++ b/charts/archivista/Chart.yaml
@@ -17,7 +17,7 @@ name: archivista
 description: A Helm chart for Archivista
 
 type: application
-version: 0.7.0
+version: 0.8.0
 
 keywords:
   - in-toto
@@ -34,4 +34,4 @@ sources:
 maintainers:
   - name: in-toto
 
-appVersion: "0.7.0"
+appVersion: "0.9.0"

--- a/charts/archivista/values.yaml
+++ b/charts/archivista/values.yaml
@@ -17,7 +17,7 @@ image:
   repository: ghcr.io/in-toto/archivista
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.8.0"
+  tag: "0.9.0"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Update Archivista to v0.9.0 release.

Please, consider issue #6 during the review.