### PR TITLE
build: create dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,22 @@
+version: 2
+enable-beta-ecosystems: true
+updates:
+  - package-ecosystem: "helm" 
+    directory: "/charts/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "deps-helm"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
       prefix: "deps-helm"
       include: "scope"
     groups:
-      github-actions:
+      helm-charts:
         patterns:
           - "*"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
- Add dependabot for dependencies for helm charts (if have one in the future) Note: it requires the beta dependabot
  **It uses dependabot beta**
- Add dependabot for github actions